### PR TITLE
Implemented arguments processor.

### DIFF
--- a/include/diffr/util/ArgumentsProcessor.h
+++ b/include/diffr/util/ArgumentsProcessor.h
@@ -25,6 +25,25 @@
 #ifndef ARGUMENTSPROCESSOR_H
 #define	ARGUMENTSPROCESSOR_H
 
-void processArguments();
+#include <stdbool.h>
+
+/**
+ * Checks if the given arguments contain a call for help.
+ * 
+ * @param noArguments the number of arguments.
+ * @param arguments the arguments to check for help.
+ * @return true if the given arguments contain a call for help, 
+ * false otherwise.
+ */
+bool containsHelpArgument(int noArguments, char** arguments);
+
+/**
+ * Extract the output file location from the given arguments.
+ *
+ * @param noArguments the number of arguments.
+ * @param arguments the arguments to extract the output file location from.
+ * @return the output file location from the given arguments.
+ */
+char* extractOutputFile(int noArguments, char** arguments);
 
 #endif	/* ARGUMENTSPROCESSOR_H */

--- a/src/util/ArgumentsProcessor.c
+++ b/src/util/ArgumentsProcessor.c
@@ -1,6 +1,6 @@
 /**
  * @file ArgumentsProcessor.c
- * @author  William Martin <will.st4@gmail.com>
+ * @author William Martin <will.st4@gmail.com>
  * @since 0.0
  *
  * @section LICENSE
@@ -22,8 +22,26 @@
  *
  */
 
+#include <strings.h>
 #include "diffr/util/ArgumentsProcessor.h"
 
-void processArguments(){
-    
+bool containsHelpArgument(int noArguments, char** arguments) {
+  for (int i = 0; i < noArguments; i++) {
+    char* s = arguments[i];
+    if (0 == strcasecmp(s, "--help")
+            || 0 == strcasecmp(s, "-help")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+char* extractOutputFile(int noArguments, char** arguments) {
+  for (int i = 0; i < noArguments - 1; i++) {
+    char* s = arguments[i];
+    if (0 == strcasecmp(s, "-o")) {
+      return arguments[i + 1];
+    }
+  }
+  return NULL;
 }

--- a/test/src/util/ArgumentsProcessorTest.cpp
+++ b/test/src/util/ArgumentsProcessorTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @file ArgumentsProcessorTest.cpp
  * @author  William Martin <will.st4@gmail.com>
- * @version 0.0
+ * @since 0.0
  *
  * @section LICENSE
  *
@@ -22,6 +22,8 @@
  * 
  */
 
+#include <string.h>
+
 #include "gtest/gtest.h"
 
 extern "C" {
@@ -30,28 +32,130 @@ extern "C" {
 
 namespace {
 
-    /**
-     * Tests ArgumentsProcessor.
-     * 
-     */
-    class ArgumentsProcessorTest : public ::testing::Test {
-    protected:
+  /**
+   * Tests ArgumentsProcessor.
+   * 
+   */
+  class ArgumentsProcessorTest : public ::testing::Test {
+  protected:
 
-        ArgumentsProcessorTest() {
+    ArgumentsProcessorTest() {
 
-        }
+    }
 
-        virtual ~ArgumentsProcessorTest() {
+    virtual ~ArgumentsProcessorTest() {
 
-        }
+    }
 
-    };
+  };
 };
 
 /*
- * Tests whether the processArguments method works correctly.
+ * Tests whether the containsHelpArgument function works correctly.
  * 
  */
-TEST_F(ArgumentsProcessorTest, ProcessArgumentsTest) {
-    processArguments();
+TEST_F(ArgumentsProcessorTest, ContainsHelpArgumentTest) {
+  char** arguments = (char**) malloc(5 * sizeof (char*));
+  for (int i = 0; i < 5; i++) {
+    arguments[i] = (char*) malloc(14 * sizeof (char));
+  }
+  strcpy(arguments[0], "--help");
+  EXPECT_TRUE(containsHelpArgument(1, arguments));
+
+  strcpy(arguments[0], "-help");
+  EXPECT_TRUE(containsHelpArgument(1, arguments));
+
+  strcpy(arguments[0], "--nelp");
+  EXPECT_FALSE(containsHelpArgument(1, arguments));
+
+  strcpy(arguments[0], "-nelp");
+  EXPECT_FALSE(containsHelpArgument(1, arguments));
+
+  strcpy(arguments[0], "i");
+  strcpy(arguments[1], "don't");
+  strcpy(arguments[2], "want");
+  strcpy(arguments[3], "--help");
+  strcpy(arguments[4], "");
+  EXPECT_TRUE(containsHelpArgument(5, arguments));
+
+  strcpy(arguments[0], "i");
+  strcpy(arguments[1], "don't");
+  strcpy(arguments[2], "want");
+  strcpy(arguments[3], "-help");
+  strcpy(arguments[4], "");
+  EXPECT_TRUE(containsHelpArgument(5, arguments));
+
+  strcpy(arguments[0], "i");
+  strcpy(arguments[1], "don't");
+  strcpy(arguments[2], "want");
+  strcpy(arguments[3], "--helphrthjrhj");
+  strcpy(arguments[4], "");
+  EXPECT_FALSE(containsHelpArgument(5, arguments));
+
+  strcpy(arguments[0], "i");
+  strcpy(arguments[1], "don't");
+  strcpy(arguments[2], "want");
+  strcpy(arguments[3], "rherh-help");
+  strcpy(arguments[4], "");
+  EXPECT_FALSE(containsHelpArgument(5, arguments));
+
+  for (int i = 0; i < 5; i++) {
+    free(arguments[i]);
+  }
+  free(arguments);
+}
+
+/*
+ * Tests whether the extractOutputFile function works correctly.
+ * 
+ */
+TEST_F(ArgumentsProcessorTest, ExtractOutputFileTest) {
+  char** arguments = (char**) malloc(5 * sizeof (char*));
+  for (int i = 0; i < 5; i++) {
+    arguments[i] = (char*) malloc(14 * sizeof (char));
+  }
+  strcpy(arguments[0], "-o");
+  EXPECT_EQ(NULL, extractOutputFile(1, arguments));
+
+  strcpy(arguments[0], "output");
+  EXPECT_EQ(NULL, extractOutputFile(1, arguments));
+
+  strcpy(arguments[0], "outputhere");
+  EXPECT_EQ(NULL, extractOutputFile(1, arguments));
+
+  strcpy(arguments[0], "-o dir");
+  EXPECT_EQ(NULL, extractOutputFile(1, arguments));
+
+  strcpy(arguments[0], "i");
+  strcpy(arguments[1], "-o");
+  strcpy(arguments[2], "want");
+  strcpy(arguments[3], "output");
+  strcpy(arguments[4], "here");
+  EXPECT_STREQ("want", extractOutputFile(5, arguments));
+
+  strcpy(arguments[0], "i");
+  strcpy(arguments[1], "don't");
+  strcpy(arguments[2], "want");
+  strcpy(arguments[3], "-help");
+  strcpy(arguments[4], "-o");
+  EXPECT_EQ(NULL, extractOutputFile(5, arguments));
+
+  strcpy(arguments[0], "i");
+  strcpy(arguments[1], "don't");
+  strcpy(arguments[2], "want");
+  strcpy(arguments[3], "--helphrthjrhj");
+  strcpy(arguments[4], "-o-o");
+  EXPECT_EQ(NULL, extractOutputFile(5, arguments));
+
+  strcpy(arguments[0], "-o");
+  strcpy(arguments[1], "output");
+  strcpy(arguments[2], "-o");
+  strcpy(arguments[3], "rherh-help");
+  strcpy(arguments[4], "");
+  EXPECT_STREQ("output", extractOutputFile(5, arguments));
+
+  for (int i = 0; i < 5; i++) {
+    free(arguments[i]);
+  }
+  free(arguments);
 }


### PR DESCRIPTION
Ported functions from diffr-java:
- Intention is to run directly on argc and argv, so I've used char*\* and libc string compare functions.
- Included int parameter to the functions for argc, since the array size isn't known at compile time.
- `containsHelpArgument` function returns bool from `<stdbool.h>`, but maybe we want some boolean type from glib instead?
